### PR TITLE
Corrected variable usage in connect func

### DIFF
--- a/Bluefruit/Common/AdafruitKit/Ble/BleCentralMode/BleManager.swift
+++ b/Bluefruit/Common/AdafruitKit/Ble/BleCentralMode/BleManager.swift
@@ -179,8 +179,8 @@ class BleManager: NSObject {
 
         #if os(OSX)
         #else
-            if shouldNotifyOnConnection || shouldNotifyOnDisconnection || shouldNotifyOnDisconnection {
-                options = [CBConnectPeripheralOptionNotifyOnConnectionKey: shouldNotifyOnConnection, CBConnectPeripheralOptionNotifyOnDisconnectionKey: shouldNotifyOnDisconnection, CBConnectPeripheralOptionNotifyOnNotificationKey: shouldNotifyOnDisconnection]
+            if shouldNotifyOnConnection || shouldNotifyOnDisconnection || shouldNotifyOnNotification {
+                options = [CBConnectPeripheralOptionNotifyOnConnectionKey: shouldNotifyOnConnection, CBConnectPeripheralOptionNotifyOnDisconnectionKey: shouldNotifyOnDisconnection, CBConnectPeripheralOptionNotifyOnNotificationKey: shouldNotifyOnNotification]
             }
         #endif
 


### PR DESCRIPTION
We're not actually checking the correct variable in the conditional. It seems to me that we should check the `shouldNotifyOnNotification` while we're checking `shouldNotifyOnDisconnection` twice.